### PR TITLE
Dl 7553

### DIFF
--- a/app/views/components/headingNew.scala.html
+++ b/app/views/components/headingNew.scala.html
@@ -1,0 +1,29 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+@(headingKey: String, subHeading: Option[String] = None)(implicit messages: Messages)
+
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-5">
+    @subHeading.map { x =>
+        <span class="hmrc-caption govuk-caption-xl">
+            <span class="govuk-visually-hidden">@messages("site.section.prefix")</span>
+                @messages(x)
+        </span>
+    }
+        @messages(headingKey)
+    </h1>
+

--- a/app/views/components/headingNew.scala.html
+++ b/app/views/components/headingNew.scala.html
@@ -17,13 +17,13 @@
 @this()
 @(headingKey: String, subHeading: Option[String] = None)(implicit messages: Messages)
 
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-5">
+<h1 class="govuk-heading-xl hmrc-page-heading govuk-!-margin-bottom-5">
+    @messages(headingKey)
     @subHeading.map { x =>
         <span class="hmrc-caption govuk-caption-xl">
             <span class="govuk-visually-hidden">@messages("site.section.prefix")</span>
                 @messages(x)
         </span>
     }
-        @messages(headingKey)
-    </h1>
+</h1>
 

--- a/app/views/components/input_yes_no_hidden_legendNew.scala.html
+++ b/app/views/components/input_yes_no_hidden_legendNew.scala.html
@@ -1,0 +1,53 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
+
+@this(radios: GovukRadios)
+@(
+        legendKey: String,
+        field: Field,
+        hintKey: Option[String] = None,
+        yesHtml: Option[Html] = None,
+        noHtml: Option[Html] = None,
+        inline: Boolean = true)(implicit messages: Messages
+)
+@radios(
+    Radios(
+        hint = if(hintKey.isDefined) Some(Hint(content = Text(messages(hintKey.get)))) else None,
+        fieldset = Some(Fieldset(
+            legend = Some(Legend(
+                content = Text(messages(legendKey)),
+                classes = "govuk-visually-hidden"
+            ))
+        )),
+        items = Seq(
+            RadioItem(
+                content = Text(messages("site.yes")),
+                value = Some("true"),
+                conditionalHtml = yesHtml,
+            ),
+            RadioItem(
+                content = Text(messages("site.no")),
+                value = Some("false"),
+                conditionalHtml = noHtml,
+            )
+        ),
+        classes = if(inline) "govuk-radios--inline" else ""
+    ).withFormField(field)
+)
+

--- a/app/views/components/new_tab_linkNew.scala.html
+++ b/app/views/components/new_tab_linkNew.scala.html
@@ -1,0 +1,20 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+@(linkMsgKey: String, href: String, id: Option[String] = None)(implicit messages: Messages)
+<a class="govuk-link" @id.map { id => id="@id" } href="@href" rel="noreferrer noopener" target="_blank">
+@messages(linkMsgKey) @messages("site.opensInNewTab")</a>

--- a/app/views/sections/businessOnOwnAccount/MajorityOfWorkingTimeView.scala.html
+++ b/app/views/sections/businessOnOwnAccount/MajorityOfWorkingTimeView.scala.html
@@ -19,36 +19,34 @@
 @import controllers.sections.businessOnOwnAccount.routes._
 @import models.Mode
 @import views.ViewUtils._
+@import views.html.templates.layout
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import views.html.components._
 
-@this(formWithCsrf: FormWithCSRF, mainTemplate: templates.MainTemplate)
+@this(formWithCsrf: FormWithCSRF, layout: layout, errorSummary: GovukErrorSummary, submit: submit_button_new, radios: input_yes_no_hidden_legendNew, heading: headingNew, newTabLink: new_tab_linkNew)
 
 @(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages, appConfig: FrontendAppConfig)
 
-@mainTemplate(
-    title = title(form, tailorMsg("majorityOfWorkingTime.title"), Some(tailorMsg("majorityOfWorkingTime.subheading"))),
+@layout(
+    pageTitle = title(form, tailorMsg("majorityOfWorkingTime.title"), Some(tailorMsg("majorityOfWorkingTime.subheading"))),
     appConfig = appConfig,
-    bodyClasses = None) {
+    mode = mode) {
 
-    @components.back_link()(mode)
+    @if(form.errors.nonEmpty) {
+        @errorSummary(ErrorSummary().withFormErrorsAsText(form))
+    }
+
+    @heading(tailorMsg("majorityOfWorkingTime.title"), Some(tailorMsg("majorityOfWorkingTime.subheading")))
 
     @formWithCsrf(action = MajorityOfWorkingTimeController.onSubmit(mode), 'autoComplete -> "off") {
 
-        @components.error_summary(form.errors)
+        <p class="govuk-body">@messages(tailorMsg("majorityOfWorkingTime.p1"))</p>
+        <p class="govuk-body">@messages(tailorMsg("majorityOfWorkingTime.p2"))
+            @newTabLink(tailorMsg("majorityOfWorkingTime.p2.link"), appConfig.employmentStatusManualESM11160Url, Some("employmentStatusManualLink")).
+        </p>
 
-        @components.input_yes_no(
-            field = form("value"),
-            legend = components.heading(tailorMsg("majorityOfWorkingTime.heading"), Some(tailorMsg("majorityOfWorkingTime.subheading")), asLegend = true),
-            labelClass = Some("visually-hidden"),
-            otherContent = Some(p1)
-        )
-
-        @components.submit_button()
+    @radios(tailorMsg("majorityOfWorkingTime.title"), form("value"))
+        @submit()
     }
-}
-
-@p1 = {
-    <p>@messages(tailorMsg("majorityOfWorkingTime.p1"))</p>
-    <p>@messages(tailorMsg("majorityOfWorkingTime.p2"))
-        @components.new_window_link(tailorMsg("majorityOfWorkingTime.p2.link"), appConfig.employmentStatusManualESM11160Url, Some("employmentStatusManualLink")).
-    </p>
 }

--- a/app/views/sections/businessOnOwnAccount/MajorityOfWorkingTimeView.scala.html
+++ b/app/views/sections/businessOnOwnAccount/MajorityOfWorkingTimeView.scala.html
@@ -47,6 +47,8 @@
         </p>
 
     @radios(tailorMsg("majorityOfWorkingTime.title"), form("value"))
-        @submit()
+
+    @submit()
+
     }
 }

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -83,7 +83,7 @@ site.letter.dateOfResult = Dyddiad y canlyniad:
 site.letter.version = Gwasanaeth Penderfynu, fersiwn:
 site.letter.version.disclaimer = Bydd CThEM yn glynu wrth eich canlyniad oni bai bod arferion gwaith wedi newid ac, os ydynt wedi newid, dylech ddefnyddio’r gwasanaeth hwn eto i adlewyrchu’r newidiadau hynny.
 site.letter.footer = Tudalen {0} o {1}
-site.section.prefix = Teitl yr adran hon yw 
+site.section.prefix = Teitl yr adran hon yw
 
 site.accordion.openAll = Agor pob un
 site.accordion.closeAll = Cau pob un

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -67,6 +67,7 @@ site.govuk = GOV.UK
 site.employmentStatusManual = Canllaw Statws Cyflogaeth
 site.telephone = Ffôn:
 site.telephone.number = 0300 200 1900
+site.opensInNewTab = (yn agor tab newydd)
 site.opensInNewWindow = (yn agor mewn ffenestr newydd)
 site.opensInNewWindowOrTab = (yn agor ffenestr neu dab newydd)
 
@@ -82,6 +83,7 @@ site.letter.dateOfResult = Dyddiad y canlyniad:
 site.letter.version = Gwasanaeth Penderfynu, fersiwn:
 site.letter.version.disclaimer = Bydd CThEM yn glynu wrth eich canlyniad oni bai bod arferion gwaith wedi newid ac, os ydynt wedi newid, dylech ddefnyddio’r gwasanaeth hwn eto i adlewyrchu’r newidiadau hynny.
 site.letter.footer = Tudalen {0} o {1}
+site.section.prefix = Teitl yr adran hon yw 
 
 site.accordion.openAll = Agor pob un
 site.accordion.closeAll = Cau pob un

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -69,7 +69,7 @@ site.accordion.openAll = Open all
 site.accordion.closeAll = Close all
 site.telephone = Telephone:
 site.telephone.number = 0300 123 2326
-site.opensInNewTab = (opens in a new tab)
+site.opensInNewTab = (opens in new tab)
 site.opensInNewWindow = (opens in a new window)
 site.opensInNewWindowOrTab = (opens in a new window or tab)
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -69,6 +69,7 @@ site.accordion.openAll = Open all
 site.accordion.closeAll = Close all
 site.telephone = Telephone:
 site.telephone.number = 0300 123 2326
+site.opensInNewTab = (opens in a new tab)
 site.opensInNewWindow = (opens in a new window)
 site.opensInNewWindowOrTab = (opens in a new window or tab)
 
@@ -84,6 +85,7 @@ site.letter.dateOfResult = Date of result:
 site.letter.version = Decision service version:
 site.letter.version.disclaimer = HMRC will stand by this result as long as it reflects the actual or expected working practices. If these working practices change, you should use this tool again.
 site.letter.footer = Page {0} of {1}
+site.section.prefix = This section is
 
 feedback.before = This is a new service - your
 feedback.link = feedback

--- a/test/assets/messages/MajorityOfWorkingTimeMessages.scala
+++ b/test/assets/messages/MajorityOfWorkingTimeMessages.scala
@@ -24,7 +24,7 @@ object MajorityOfWorkingTimeMessages extends BaseMessages {
     val heading = "Will this work take up the majority of your available working time?"
     val subheading = "Worker’s contracts"
     val p1 = "This includes preparation or any other time necessary to deliver the work, even if it is not referred to in the contract."
-    val p2 = "Read more about the worker’s available working time (opens in a new window)."
+    val p2 = "Read more about the worker’s available working time (opens in a new tab)."
 
   }
 
@@ -34,6 +34,6 @@ object MajorityOfWorkingTimeMessages extends BaseMessages {
     val heading = "Will this work take up the majority of the worker’s available working time?"
     val subheading = "Worker’s contracts"
     val p1 = "This includes preparation or any other time necessary to deliver the work, even if it is not referred to in the contract."
-    val p2 = "Read more about the worker’s available working time (opens in a new window)."
+    val p2 = "Read more about the worker’s available working time (opens in a new tab)."
   }
 }

--- a/test/assets/messages/MajorityOfWorkingTimeMessages.scala
+++ b/test/assets/messages/MajorityOfWorkingTimeMessages.scala
@@ -24,7 +24,7 @@ object MajorityOfWorkingTimeMessages extends BaseMessages {
     val heading = "Will this work take up the majority of your available working time?"
     val subheading = "Worker’s contracts"
     val p1 = "This includes preparation or any other time necessary to deliver the work, even if it is not referred to in the contract."
-    val p2 = "Read more about the worker’s available working time (opens in a new tab)."
+    val p2 = "Read more about the worker’s available working time (opens in new tab)."
 
   }
 
@@ -34,6 +34,6 @@ object MajorityOfWorkingTimeMessages extends BaseMessages {
     val heading = "Will this work take up the majority of the worker’s available working time?"
     val subheading = "Worker’s contracts"
     val p1 = "This includes preparation or any other time necessary to deliver the work, even if it is not referred to in the contract."
-    val p2 = "Read more about the worker’s available working time (opens in a new tab)."
+    val p2 = "Read more about the worker’s available working time (opens in new tab)."
   }
 }

--- a/test/resources/welshMessages/messages.cy
+++ b/test/resources/welshMessages/messages.cy
@@ -69,6 +69,7 @@ site.telephone = Ffôn:
 site.telephone.number = 0300 200 1900
 site.opensInNewWindow = (yn agor mewn ffenestr newydd)
 site.opensInNewWindowOrTab = (yn agor ffenestr neu dab newydd)
+site.opensInNewTab = (yn agor tab newydd)
 
 site.letter.h1 = Cadwch copi o’ch penderfyniad
 site.letter.forYourRecords = Ar gyfer eich cofnodion
@@ -82,6 +83,7 @@ site.letter.dateOfResult = Dyddiad y canlyniad:
 site.letter.version = Gwasanaeth Penderfynu, fersiwn:
 site.letter.version.disclaimer = Bydd CThEM yn glynu wrth eich canlyniad oni bai bod arferion gwaith wedi newid ac, os ydynt wedi newid, dylech ddefnyddio’r gwasanaeth hwn eto i adlewyrchu’r newidiadau hynny.
 site.letter.footer = Tudalen {0} o {1}
+site.section.prefix = Teitl yr adran hon yw
 
 site.accordion.openAll = Agor pob un
 site.accordion.closeAll = Cau pob un

--- a/test/views/sections/businessOnOwnAccount/MajorityOfWorkingTimeViewSpec.scala
+++ b/test/views/sections/businessOnOwnAccount/MajorityOfWorkingTimeViewSpec.scala
@@ -17,15 +17,14 @@
 package views.sections.businessOnOwnAccount
 
 import assets.messages.MajorityOfWorkingTimeMessages
-import controllers.sections.businessOnOwnAccount.routes
 import forms.sections.businessOnOwnAccount.MajorityOfWorkingTimeFormProvider
 import models.NormalMode
 import play.api.data.Form
 import play.api.mvc.Request
-import views.behaviours.YesNoViewBehaviours
+import views.behaviours.YesNoViewBehavioursNew
 import views.html.sections.businessOnOwnAccount.MajorityOfWorkingTimeView
 
-class MajorityOfWorkingTimeViewSpec extends YesNoViewBehaviours {
+class MajorityOfWorkingTimeViewSpec extends YesNoViewBehavioursNew {
 
   object Selectors extends BaseCSSSelectors
 
@@ -47,7 +46,7 @@ class MajorityOfWorkingTimeViewSpec extends YesNoViewBehaviours {
 
     behave like pageWithBackLink(createView)
 
-    behave like yesNoPage(createViewUsingForm, messageKeyPrefix, routes.MajorityOfWorkingTimeController.onSubmit(NormalMode).url)
+    behave like yesNoPage(createViewUsingForm, messageKeyPrefix)
 
     "the WhoAreYou is Worker" must {
 
@@ -58,7 +57,7 @@ class MajorityOfWorkingTimeViewSpec extends YesNoViewBehaviours {
       }
 
       "have the correct heading" in {
-        document.select(Selectors.heading).text mustBe MajorityOfWorkingTimeMessages.Worker.heading
+        document.select(Selectors.heading).text must include(MajorityOfWorkingTimeMessages.Worker.heading)
       }
 
       "have the correct p1" in {
@@ -68,9 +67,6 @@ class MajorityOfWorkingTimeViewSpec extends YesNoViewBehaviours {
       "have the correct p2" in {
         document.select(Selectors.p(2)).text mustBe MajorityOfWorkingTimeMessages.Worker.p2
       }
-
-      document.select(Selectors.p(2)).text mustBe MajorityOfWorkingTimeMessages.Worker.p2
-
 
       "have the correct radio option messages" in {
         document.select(Selectors.multichoice(1)).text mustBe MajorityOfWorkingTimeMessages.yes
@@ -91,7 +87,7 @@ class MajorityOfWorkingTimeViewSpec extends YesNoViewBehaviours {
       }
 
       "have the correct heading" in {
-        document.select(Selectors.heading).text mustBe MajorityOfWorkingTimeMessages.Hirer.heading
+        document.select(Selectors.heading).text must include(MajorityOfWorkingTimeMessages.Hirer.heading)
       }
 
       "have the correct p1" in {


### PR DESCRIPTION
# DL-7553 - Migrate MajorityOfWorkingTimeView

**New feature**

Migrated MajorityOfWorkingTimeView, created components for radios where the legend isn't the h1 and a heading component.

Acceptance test PR: https://github.com/hmrc/off-payroll-acceptance-tests/pull/175

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
