### PR TITLE
DL-6875: Migrate ArrangedSubstituteView

### DIFF
--- a/app/views/sections/personalService/ArrangedSubstituteView.scala.html
+++ b/app/views/sections/personalService/ArrangedSubstituteView.scala.html
@@ -15,39 +15,38 @@
  *@
 
 @import config.FrontendAppConfig
-@import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 @import controllers.sections.personalService.routes._
-@import models.sections.personalService.ArrangedSubstitute
 @import models.Mode
+@import models.sections.personalService.ArrangedSubstitute
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 @import views.ViewUtils._
+@import views.html.components.{headingNew, input_radio_new, submit_button_new}
+@import views.html.templates.layout
 
-@this(formWithCsrf: FormWithCSRF, mainTemplate: templates.MainTemplate)
+@this(formWithCsrf: FormWithCSRF, layout: layout, heading: headingNew,  errorSummary: GovukErrorSummary, radios: input_radio_new, submit: submit_button_new)
 
 @(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages, appConfig: FrontendAppConfig)
 
-@mainTemplate(
-    title = title(form, tailorMsg("arrangedSubstitute.title"), Some(tailorMsg("arrangedSubstitute.subheading"))),
+@layout(
+    pageTitle = title(form, tailorMsg("arrangedSubstitute.title"), Some(tailorMsg("arrangedSubstitute.subheading"))),
     appConfig = appConfig,
-    bodyClasses = None) {
-
-    @components.back_link()(mode)
+    mode = mode) {
 
     @formWithCsrf(action = ArrangedSubstituteController.onSubmit(mode), 'autoComplete -> "off") {
 
-        @components.error_summary(form.errors)
+        @if(form.errors.nonEmpty) {
+            @errorSummary(ErrorSummary().withFormErrorsAsText(form))
+        }
 
-        @components.input_radio(
-            field = form("value"),
-            legend = components.heading(tailorMsg("arrangedSubstitute.heading"), Some(tailorMsg("arrangedSubstitute.subheading")), asLegend = true),
-            legendClass = Some("visually-hidden"),
-            inputs = ArrangedSubstitute.options,
-            otherContent = Some(content)
-        )
+        @heading(tailorMsg("arrangedSubstitute.heading"), Some(tailorMsg("arrangedSubstitute.subheading")))
 
-        @components.submit_button()
+        <p class="govuk-body">@messages(tailorMsg("arrangedSubstitute.p1"))</p>
+
+        @radios(tailorMsg("arrangedSubstitute.heading"), form("value"), ArrangedSubstitute.options)
+
+        @submit()
     }
 }
 
-@content = {
-    <p>@messages(tailorMsg("arrangedSubstitute.p1"))</p>
-}

--- a/test/views/sections/personalService/ArrangedSubstituteViewSpec.scala
+++ b/test/views/sections/personalService/ArrangedSubstituteViewSpec.scala
@@ -21,10 +21,10 @@ import forms.sections.personalService.ArrangedSubstituteFormProvider
 import models.NormalMode
 import play.api.data.Form
 import play.api.mvc.Request
-import views.behaviours.ViewBehaviours
+import views.behaviours.ViewBehavioursNew
 import views.html.sections.personalService.ArrangedSubstituteView
 
-class ArrangedSubstituteViewSpec extends ViewBehaviours {
+class ArrangedSubstituteViewSpec extends ViewBehavioursNew {
 
   object Selectors extends BaseCSSSelectors
 
@@ -54,7 +54,7 @@ class ArrangedSubstituteViewSpec extends ViewBehaviours {
       }
 
       "have the correct heading" in {
-        document.select(Selectors.heading).text mustBe ArrangedSubstituteMessages.Worker.heading
+        document.select(Selectors.heading).text must include(ArrangedSubstituteMessages.Worker.heading)
       }
 
       "have the correct content" in {
@@ -77,7 +77,7 @@ class ArrangedSubstituteViewSpec extends ViewBehaviours {
       }
 
       "have the correct heading" in {
-        document.select(Selectors.heading).text mustBe ArrangedSubstituteMessages.Hirer.heading
+        document.select(Selectors.heading).text must include(ArrangedSubstituteMessages.Hirer.heading)
       }
 
       "have the correct content" in {
@@ -100,7 +100,7 @@ class ArrangedSubstituteViewSpec extends ViewBehaviours {
       }
 
       "have the correct heading" in {
-        document.select(Selectors.heading).text mustBe ArrangedSubstituteMessages.Worker.heading
+        document.select(Selectors.heading).text must include(ArrangedSubstituteMessages.Worker.heading)
       }
 
       "have the correct content" in {


### PR DESCRIPTION
# DL-6875: Migrate ArrangedSubstituteView

**New feature**

Update ArrangedSubstituteView to use play-frontend-hmrc

PR for ATs: https://github.com/hmrc/off-payroll-acceptance-tests/pull/196

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
