### PR TITLE
DL-9348b downgrade chat and caching dependencies

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,20 +2,19 @@ import sbt._
 
 object AppDependencies {
 
-  val wireMockVersion = "2.32.0"
   val wireMockStandAloneVersion = "2.27.2"
 
   val compile = Seq(
     play.sbt.PlayImport.ws,
     "uk.gov.hmrc"       %% "play-frontend-hmrc"               % "6.0.0-play-28",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"               % "0.74.0",
-    "uk.gov.hmrc"       %% "govuk-template"                   % "5.78.0-play-28",
-    "uk.gov.hmrc"       %% "play-ui"                          % "9.11.0-play-28",
-    "uk.gov.hmrc"       %% "http-caching-client"              % "10.0.0-play-28",
+    "uk.gov.hmrc"       %% "govuk-template"                   % "5.77.0-play-28",
+    "uk.gov.hmrc"       %% "play-ui"                          % "9.10.0-play-28",
+    "uk.gov.hmrc"       %% "http-caching-client"              % "9.6.0-play-28",
     "uk.gov.hmrc"       %% "play-conditional-form-mapping"    % "1.12.0-play-28",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"       % "5.25.0",
     "com.typesafe.play" %% "play-json-joda"                   % "2.9.3",
-    "uk.gov.hmrc"       %% "digital-engagement-platform-chat" % "0.32.0-play-28"
+    "uk.gov.hmrc"       %% "digital-engagement-platform-chat" % "0.29.0-play-28"
   )
 
   val test: Seq[ModuleID] = Seq(


### PR DESCRIPTION
Downgrading http-caching-client and digital-engagement-platform-chat dependencies as were causing issues when viewing application in staging

Left the govuk-template and plat-ui dependency versions as on the original repo as these will be removed in any case after the migration task is complete

Unit It and ATs all pass locally