### PR TITLE
DL-7570 migration of identifyToStakeholdersView page

### DIFF
--- a/app/views/sections/partParcel/IdentifyToStakeholdersView.scala.html
+++ b/app/views/sections/partParcel/IdentifyToStakeholdersView.scala.html
@@ -20,29 +20,39 @@
 @import models.sections.partAndParcel.IdentifyToStakeholders
 @import models.Mode
 @import views.ViewUtils._
+@import views.html.templates.layout
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import views.html.components._
 
-@this(formWithCsrf: FormWithCSRF, mainTemplate: templates.MainTemplate)
+@this(formWithCsrf: FormWithCSRF,
+        layout: layout,
+        errorSummary: GovukErrorSummary,
+        radios: input_radio_new,
+        submit: submit_button_new,
+        heading: headingNew)
 
 @(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages, appConfig: FrontendAppConfig)
 
-@mainTemplate(
-    title = title(form, tailorMsg("identifyToStakeholders.title"), Some(tailorMsg("identifyToStakeholders.subheading"))),
+@layout(
+    pageTitle = title(form, tailorMsg("identifyToStakeholders.title"), Some(tailorMsg("identifyToStakeholders.subheading"))),
     appConfig = appConfig,
-    bodyClasses = None) {
+    mode = mode) {
 
-    @components.back_link()(mode)
+    @if(form.errors.nonEmpty) {
+        @errorSummary(ErrorSummary().withFormErrorsAsText(form))
+    }
+
+    @heading(tailorMsg("identifyToStakeholders.heading"), Some(tailorMsg("identifyToStakeholders.subheading")))
 
     @formWithCsrf(action = IdentifyToStakeholdersController.onSubmit(mode), 'autoComplete -> "off") {
 
-        @components.error_summary(form.errors)
-
-        @components.input_radio(
+        @radios(
             field = form("value"),
-            legend = components.heading(tailorMsg("identifyToStakeholders.heading"), Some(tailorMsg("identifyToStakeholders.subheading")), asLegend = true),
-            legendClass = Some("visually-hidden"),
-            inputs = IdentifyToStakeholders.options
+            legendKey = tailorMsg("identifyToStakeholders.heading"),
+            radioItems = IdentifyToStakeholders.options
         )
 
-        @components.submit_button()
+        @submit()
     }
 }

--- a/test/views/sections/partParcel/IdentifyToStakeholdersViewSpec.scala
+++ b/test/views/sections/partParcel/IdentifyToStakeholdersViewSpec.scala
@@ -22,10 +22,10 @@ import models.NormalMode
 import models.sections.partAndParcel.IdentifyToStakeholders
 import play.api.data.Form
 import play.api.mvc.Request
-import views.behaviours.ViewBehaviours
+import views.behaviours.ViewBehavioursNew
 import views.html.sections.partParcel.IdentifyToStakeholdersView
 
-class IdentifyToStakeholdersViewSpec extends ViewBehaviours {
+class IdentifyToStakeholdersViewSpec extends ViewBehavioursNew {
 
   object Selectors extends BaseCSSSelectors
 
@@ -55,7 +55,7 @@ class IdentifyToStakeholdersViewSpec extends ViewBehaviours {
       }
 
       "have the correct heading" in {
-        document.select(Selectors.heading).text mustBe IdentifyToStakeholdersMessages.Worker.heading
+        document.select(Selectors.heading).text must include (IdentifyToStakeholdersMessages.Worker.heading)
       }
 
       "have the correct radio options" in {
@@ -75,7 +75,7 @@ class IdentifyToStakeholdersViewSpec extends ViewBehaviours {
       }
 
       "have the correct heading" in {
-        document.select(Selectors.heading).text mustBe IdentifyToStakeholdersMessages.Hirer.heading
+        document.select(Selectors.heading).text must include (IdentifyToStakeholdersMessages.Hirer.heading)
       }
 
       "have the correct radio options" in {
@@ -95,7 +95,7 @@ class IdentifyToStakeholdersViewSpec extends ViewBehaviours {
       }
 
       "have the correct heading" in {
-        document.select(Selectors.heading).text mustBe IdentifyToStakeholdersMessages.Worker.heading
+        document.select(Selectors.heading).text must include (IdentifyToStakeholdersMessages.Worker.heading)
       }
 
       "have the correct radio options" in {
@@ -112,20 +112,19 @@ class IdentifyToStakeholdersViewSpec extends ViewBehaviours {
       "contain radio buttons for the value" in {
         val doc = asDocument(createViewUsingForm(form))
         for (option <- IdentifyToStakeholders.options) {
-          assertContainsRadioButton(doc, option.id, "value", option.value, isChecked = false)
+          assertContainsRadioButton(doc, idHelper(IdentifyToStakeholders.options, option), "value", option.value, isChecked = false)
         }
       }
     }
-
 
     for(option <- IdentifyToStakeholders.options) {
       s"rendered with a value of '${option.value}'" must {
         s"have the '${option.value}' radio button selected" in {
           val doc = asDocument(createViewUsingForm(form.bind(Map("value" -> s"${option.value}"))))
-          assertContainsRadioButton(doc, option.id, "value", option.value, isChecked = true)
+          assertContainsRadioButton(doc, idHelper(IdentifyToStakeholders.options, option), "value", option.value, isChecked = true)
 
           for(unselectedOption <- IdentifyToStakeholders.options.filterNot(o => o == option)) {
-            assertContainsRadioButton(doc, unselectedOption.id, "value", unselectedOption.value, isChecked = false)
+            assertContainsRadioButton(doc, idHelper(IdentifyToStakeholders.options, unselectedOption), "value", unselectedOption.value, isChecked = false)
           }
         }
       }


### PR DESCRIPTION
Migrate identifyToStakeholdersView
Fix unit tests

Note - separate ATs to support this PR:
https://github.com/hmrc/off-payroll-acceptance-tests/pull/209