### PR TITLE
DL-7575 migration of WouldWorkerPaySubstituteView page

### DIFF
--- a/app/views/sections/personalService/WouldWorkerPaySubstituteView.scala.html
+++ b/app/views/sections/personalService/WouldWorkerPaySubstituteView.scala.html
@@ -19,33 +19,44 @@
 @import controllers.sections.personalService.routes._
 @import models.Mode
 @import views.ViewUtils._
+@import views.html.templates.layout
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import views.html.components._
 
-@this(formWithCsrf: FormWithCSRF, mainTemplate: templates.MainTemplate)
+@this(formWithCsrf: FormWithCSRF,
+        layout: layout,
+        errorSummary: GovukErrorSummary,
+        input_yes_no: input_yes_no_new,
+        submit: submit_button_new,
+        heading: headingNew)
 
 @(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages, appConfig: FrontendAppConfig)
 
-@mainTemplate(
-    title = title(form, tailorMsg("wouldWorkerPaySubstitute.title"), Some(tailorMsg("wouldWorkerPaySubstitute.subheading"))),
+@layout(
+    pageTitle = title(form, tailorMsg("wouldWorkerPaySubstitute.title"), Some(tailorMsg("wouldWorkerPaySubstitute.subheading"))),
     appConfig = appConfig,
-    bodyClasses = None) {
+    mode = mode) {
 
-    @components.back_link()(mode)
+    @if(form.errors.nonEmpty) {
+        @errorSummary(ErrorSummary().withFormErrorsAsText(form))
+    }
+
+    @heading(tailorMsg("wouldWorkerPaySubstitute.heading"), Some(tailorMsg("wouldWorkerPaySubstitute.subheading")))
 
     @formWithCsrf(action = WouldWorkerPaySubstituteController.onSubmit(mode), 'autoComplete -> "off") {
 
-        @components.error_summary(form.errors)
+        @p1
 
-        @components.input_yes_no(
+        @input_yes_no(
             field = form("value"),
-            legend = components.heading(tailorMsg("wouldWorkerPaySubstitute.heading"), Some(tailorMsg("wouldWorkerPaySubstitute.subheading")), asLegend = true),
-            labelClass = Some("visually-hidden"),
-            otherContent = Some(p1)
+            legendKey = tailorMsg("wouldWorkerPaySubstitute.heading")
         )
 
-        @components.submit_button()
+        @submit()
     }
 }
 
 @p1 = {
-    <p>@messages(tailorMsg("wouldWorkerPaySubstitute.hint"))</p>
+    <p class="govuk-body">@messages(tailorMsg("wouldWorkerPaySubstitute.hint"))</p>
 }

--- a/test/views/sections/personalService/WouldWorkerPaySubstituteViewSpec.scala
+++ b/test/views/sections/personalService/WouldWorkerPaySubstituteViewSpec.scala
@@ -22,10 +22,10 @@ import forms.sections.personalService.WouldWorkerPaySubstituteFormProvider
 import models.NormalMode
 import play.api.data.Form
 import play.api.mvc.Request
-import views.behaviours.YesNoViewBehaviours
+import views.behaviours.{YesNoViewBehaviours, YesNoViewBehavioursNew}
 import views.html.sections.personalService.WouldWorkerPaySubstituteView
 
-class WouldWorkerPaySubstituteViewSpec extends YesNoViewBehaviours {
+class WouldWorkerPaySubstituteViewSpec extends YesNoViewBehavioursNew {
 
   object Selectors extends BaseCSSSelectors
 
@@ -47,7 +47,7 @@ class WouldWorkerPaySubstituteViewSpec extends YesNoViewBehaviours {
 
     behave like pageWithBackLink(createView)
 
-    behave like yesNoPage(createViewUsingForm, messageKeyPrefix, routes.WouldWorkerPaySubstituteController.onSubmit(NormalMode).url)
+    behave like yesNoPage(createViewUsingForm, messageKeyPrefix)
 
     "If the user type is of Worker" should {
 
@@ -58,7 +58,7 @@ class WouldWorkerPaySubstituteViewSpec extends YesNoViewBehaviours {
       }
 
       "have the correct heading" in {
-        document.select(Selectors.heading).text mustBe WouldPaySubstituteMessages.Worker.heading
+        document.select(Selectors.heading).text must include (WouldPaySubstituteMessages.Worker.heading)
       }
 
       "have the correct p1" in {
@@ -80,7 +80,7 @@ class WouldWorkerPaySubstituteViewSpec extends YesNoViewBehaviours {
       }
 
       "have the correct heading" in {
-        document.select(Selectors.heading).text mustBe WouldPaySubstituteMessages.Hirer.heading
+        document.select(Selectors.heading).text must include (WouldPaySubstituteMessages.Hirer.heading)
       }
 
       "have the correct p1" in {
@@ -102,7 +102,7 @@ class WouldWorkerPaySubstituteViewSpec extends YesNoViewBehaviours {
       }
 
       "have the correct heading" in {
-        document.select(Selectors.heading).text mustBe WouldPaySubstituteMessages.Worker.heading
+        document.select(Selectors.heading).text must include (WouldPaySubstituteMessages.Worker.heading)
       }
 
       "have the correct p1" in {


### PR DESCRIPTION
Migrate WouldWorkerPaySubstituteView
Fix unit tests

Note - separate ATs to support this PR:
https://github.com/hmrc/off-payroll-acceptance-tests/pull/214
