### PR TITLE
DL-7586 migration of AddReferenceDetailsView page

### DIFF
--- a/app/views/AddReferenceDetailsView.scala.html
+++ b/app/views/AddReferenceDetailsView.scala.html
@@ -19,38 +19,52 @@
 @import controllers.routes._
 @import models.Mode
 @import views.ViewUtils._
+@import views.html.templates.layout
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import views.html.components._
 
-@this(formWithCsrf: FormWithCSRF, mainTemplate: templates.MainTemplate)
+@this(formWithCsrf: FormWithCSRF,
+        layout: layout,
+        errorSummary: GovukErrorSummary,
+        radios: input_yes_no_new,
+        submit: submit_button_new,
+        heading: headingNew,
+        insetText: GovukInsetText)
 
 @(form: Form[_])(implicit request: Request[_], messages: Messages, appConfig: FrontendAppConfig)
 
-@mainTemplate(
-    title = title(form, messages("addReferenceDetails.title")),
-    appConfig = appConfig,
-    bodyClasses = None) {
+@layout(
+    pageTitle = title(form, messages("addReferenceDetails.title")),
+    appConfig = appConfig) {
 
-    @components.back_link()()
+    @if(form.errors.nonEmpty) {
+        @errorSummary(ErrorSummary().withFormErrorsAsText(form))
+    }
+
+    @heading("addReferenceDetails.heading")
 
     @formWithCsrf(action = AddReferenceDetailsController.onSubmit(), 'autoComplete -> "off") {
 
-        @components.error_summary(form.errors)
+        @panel
 
-        @components.input_yes_no(
+        @otherContent
+
+        @radios(
             field = form("value"),
-            legend = components.heading(messages("addReferenceDetails.heading"), asLegend = true),
-            labelClass = Some("visually-hidden"),
-            otherContent = Some(otherContent)
+            legendKey = "addReferenceDetails.heading"
         )
 
-        @components.submit_button()
+        @submit()
     }
 }
 
 @otherContent = {
-    @components.panel_indent(panel)
-    <p>@messages("addReferenceDetails.yourRecordsOnly")</p>
+    <p class="govuk-body">@messages("addReferenceDetails.yourRecordsOnly")</p>
 }
 
 @panel = {
-    <p>@messages("addReferenceDetails.example")</p>
+    @insetText(InsetText(
+        content = Text(messages("addReferenceDetails.example"))
+    ))
 }

--- a/test/assets/messages/AddReferenceDetailsMessages.scala
+++ b/test/assets/messages/AddReferenceDetailsMessages.scala
@@ -20,6 +20,7 @@ object AddReferenceDetailsMessages extends BaseMessages {
 
   val heading = "Do you want to add some details to this document?"
   val title = heading
-  val p1 = "For example, contract information, job title or hiring department. You will get a document that shows today’s date and time of completion, your answers and your result. This is for your records only, HMRC will not keep these details."
+  val panel = "For example, contract information, job title or hiring department."
+  val p1 = "You will get a document that shows today’s date and time of completion, your answers and your result. This is for your records only, HMRC will not keep these details."
 
 }

--- a/test/views/AddReferenceDetailsViewSpec.scala
+++ b/test/views/AddReferenceDetailsViewSpec.scala
@@ -20,10 +20,10 @@ import assets.messages.AddReferenceDetailsMessages
 import forms.AddReferenceDetailsFormProvider
 import play.api.data.Form
 import play.api.mvc.Request
-import views.behaviours.YesNoViewBehaviours
+import views.behaviours.{YesNoViewBehaviours, YesNoViewBehavioursNew}
 import views.html.AddReferenceDetailsView
 
-class AddReferenceDetailsViewSpec extends YesNoViewBehaviours {
+class AddReferenceDetailsViewSpec extends YesNoViewBehavioursNew {
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -60,6 +60,10 @@ class AddReferenceDetailsViewSpec extends YesNoViewBehaviours {
 
       "have the correct heading" in {
         document.select(Selectors.heading).text mustBe AddReferenceDetailsMessages.heading
+      }
+
+      "have the correct indent text" in {
+        document.select(Selectors.panel).text mustBe AddReferenceDetailsMessages.panel
       }
 
       "have the correct p1" in {


### PR DESCRIPTION
Migration of AddReferenceDetailsView page - using twirl on view as discussed as there is little point in having an internal component containing one line
Fix tests

No AT changes required as there are no sub headings for this one