### PR TITLE
DL-7593 migrate ResetAnswerWarningsView page

### DIFF
--- a/app/views/ResetAnswersWarningView.scala.html
+++ b/app/views/ResetAnswersWarningView.scala.html
@@ -19,33 +19,50 @@
 @import views.ViewUtils._
 @import controllers.routes._
 @import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+@import views.html.templates.layout
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import views.html.components._
 
-
-@this(mainTemplate: templates.MainTemplate, formWithCsrf: FormWithCSRF)
+@this(formWithCsrf: FormWithCSRF,
+        layout: layout,
+        errorSummary: GovukErrorSummary,
+        input_yes_no: input_yes_no_new,
+        insetText: GovukInsetText,
+        submit: submit_button_new,
+        heading: headingNew)
 
 @(form: Form[_])(implicit request: Request[_], messages: Messages, appConfig: FrontendAppConfig)
 
-@mainTemplate(
-    title = title(form,messages("resetAnswersWarning.title")),
-    appConfig = appConfig,
-    bodyClasses = None) {
+@layout(
+    pageTitle = title(form,messages("resetAnswersWarning.title")),
+    appConfig = appConfig) {
 
-    @components.back_link()(NormalMode)(messages)
+    @if(form.errors.nonEmpty) {
+        @errorSummary(ErrorSummary().withFormErrorsAsText(form))
+    }
+
+    @heading("resetAnswersWarning.heading")
 
     @formWithCsrf(action = ResetAnswersWarningController.onSubmit(), 'autoComplete -> "off") {
 
-        @components.error_summary(form.errors)
+        @panel
 
-        @components.input_yes_no(
+        @input_yes_no(
             field = form("value"),
-            legend = components.heading(messages("resetAnswersWarning.heading"), asLegend = true),
-            labelClass = Some("visually-hidden"),
-            otherContent = Some(components.panel_indent(Html(messages("resetAnswersWarning.hint")))),
-            yesMessage = Some(messages("resetAnswersWarning.startAgain")),
-            noMessage = Some(messages("resetAnswersWarning.goBack")),
+            legendKey = "resetAnswersWarning.heading",
+            yesContent = "resetAnswersWarning.startAgain",
+            noContent = "resetAnswersWarning.goBack",
             inline = false
         )
 
-        @components.submit_button()
+        @submit()
     }
   }
+
+@panel = {
+    @insetText(InsetText(
+        content = Text(messages("resetAnswersWarning.hint"))
+    ))
+}
+

--- a/app/views/components/input_yes_no_new.scala.html
+++ b/app/views/components/input_yes_no_new.scala.html
@@ -24,6 +24,8 @@
         hintKey: Option[String] = None,
         yesHtml: Option[Html] = None,
         noHtml: Option[Html] = None,
+        yesContent: String = "site.yes",
+        noContent: String = "site.no",
         inline: Boolean = true)(implicit messages: Messages
 )
 @radios(
@@ -37,12 +39,12 @@
         )),
         items = Seq(
             RadioItem(
-                content = Text(messages("site.yes")),
+                content = Text(messages(yesContent)),
                 value = Some("true"),
                 conditionalHtml = yesHtml,
             ),
             RadioItem(
-                content = Text(messages("site.no")),
+                content = Text(messages(noContent)),
                 value = Some("false"),
                 conditionalHtml = noHtml,
             )

--- a/test/views/ResetAnswersWarningViewSpec.scala
+++ b/test/views/ResetAnswersWarningViewSpec.scala
@@ -17,13 +17,12 @@
 package views
 
 import assets.messages.ResetAnswersMessages
-import controllers.routes
 import forms.ResetAnswersWarningFormProvider
 import play.api.data.Form
-import views.behaviours.{ViewBehaviours, YesNoViewBehaviours}
+import views.behaviours.{ViewBehavioursNew, YesNoViewBehavioursNew}
 import views.html.ResetAnswersWarningView
 
-class ResetAnswersWarningViewSpec extends YesNoViewBehaviours with ViewBehaviours {
+class ResetAnswersWarningViewSpec extends YesNoViewBehavioursNew with ViewBehavioursNew {
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -50,7 +49,7 @@ class ResetAnswersWarningViewSpec extends YesNoViewBehaviours with ViewBehaviour
 
     behave like pageWithBackLink(createView)
 
-    behave like yesNoPage(createViewUsingForm, messageKeyPrefix, routes.ResetAnswersWarningController.onSubmit().url)
+    behave like yesNoPage(createViewUsingForm, messageKeyPrefix)
 
     "have the correct title" in {
 


### PR DESCRIPTION
... and fix tests

Change to input_yes_no_new component in order to be able to amend the content view of the buttons

No changes to ATs required as there is no subheading for this one
