### PR TITLE
DL-7594 migrate StartAgainView page

### DIFF
--- a/app/views/StartAgainView.scala.html
+++ b/app/views/StartAgainView.scala.html
@@ -17,20 +17,26 @@
 @import config.FrontendAppConfig
 @import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 @import views.ViewUtils._
+@import views.html.templates.layout
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.html.components._
 
-@this(formWithCsrf: FormWithCSRF, mainTemplate: templates.MainTemplate)
+@this(formWithCsrf: FormWithCSRF,
+        layout: layout,
+        submit: submit_button_new,
+        heading: headingNew)
 
 @(appConfig: FrontendAppConfig)(implicit request: Request[_], messages: Messages)
 
-@mainTemplate(
-    title = titleNoForm("error.startAgain.title"),
+@layout(
+    pageTitle = titleNoForm("error.startAgain.title"),
     appConfig = appConfig,
-    bodyClasses = None) {
+    mode = CheckMode) {
 
-    @components.heading(messages("error.startAgain.title"))
+    @heading("error.startAgain.heading")
 
-    <p>@messages("error.startAgain.p")</p>
+    <p class="govuk-body">@messages("error.startAgain.p")</p>
 
-    @components.button_link("error.startAgain.button", routes.StartAgainController.redirectToDisclaimer.url)
+    @submit("error.startAgain.button", "startAgain", Some(routes.StartAgainController.redirectToDisclaimer.url))
 
 }

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -31,6 +31,7 @@ error.browser.title.prefix = Gwall:
 error.required = Mae angen i chi ddewis ateb
 error.summary.title = Mae problem wedi codi
 error.startAgain.title = Aeth rhywbeth o’i le
+error.startAgain.heading = Aeth rhywbeth o’i le
 error.startAgain.p = Rhowch gynnig arall ar gychwyn y twlsyn
 error.startAgain.button = Dechrau eto
 error.summary.prefix = Gwall:

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -31,6 +31,7 @@ error.browser.title.prefix = Error:
 error.required = You need to select an answer
 error.summary.title = There is a problem
 error.startAgain.title = Something went wrong
+error.startAgain.heading = Something went wrong
 error.startAgain.p = Please try starting the tool again
 error.startAgain.button = Start again
 error.summary.prefix = Error:

--- a/test/resources/welshMessages/messages.cy
+++ b/test/resources/welshMessages/messages.cy
@@ -31,6 +31,7 @@ error.browser.title.prefix = Gwall:
 error.required = Mae angen i chi ddewis ateb
 error.summary.title = Mae problem wedi codi
 error.startAgain.title = Aeth rhywbeth o’i le
+error.startAgain.heading = Aeth rhywbeth o’i le
 error.startAgain.p = Rhowch gynnig arall ar gychwyn y twlsyn
 error.startAgain.button = Dechrau eto
 error.summary.prefix = Gwall:


### PR DESCRIPTION
Migration of StartAgainView
Fixed tests
Added heading to message files and test resources

Changes applied to support change in ATs:
https://github.com/hmrc/off-payroll-acceptance-tests/pull/215