### PR TITLE
DL-7532 migration of OfficeHolderIR35View page

### DIFF
--- a/app/views/results/inside/officeHolder/OfficeHolderIR35View.scala.html
+++ b/app/views/results/inside/officeHolder/OfficeHolderIR35View.scala.html
@@ -23,16 +23,30 @@
 @import results.sections.letter._
 @import viewmodels.{LetterAnswerSections, Result, ResultMode, ResultPDF, ResultPrintPreview}
 @import controllers.routes._
+@import views.html.components._
+@import views.html.templates._
+@import results.sections.pdf._
 
-@this(mainTemplate: templates.MainTemplate, printTemplate: templates.PrintTemplate, formWithCsrf: FormWithCSRF, letterLayout: letter_layout)
+@this(layout: layout,
+        printTemplate: PrintTemplateNew,
+        additionalDetails: additional_detailNew,
+        teal_result: teal_resultNew,
+        do_next: do_nextNew,
+        why_result: why_resultNew,
+        download: downloadNew,
+        newTabLink: new_tab_linkNew,
+        keepCopy:  keep_copyNew,
+        letterLayout: letter_layout,
+        print_and_save_result: print_and_save_result_new,
+        formWithCsrf: FormWithCSRF)
 
 @(form: Form[_], isMakingDetermination: Boolean)(implicit request: DataRequest[_], messages: Messages, appConfig: FrontendAppConfig, pdfResultDetails: PDFResultDetails)
 
 @defining(
 
     pdfResultDetails.resultMode match {
-        case Result => mainTemplate(title(form, "result.title"), appConfig = appConfig)(_)
-        case ResultPrintPreview => mainTemplate(title(form, "site.letter.h1"), appConfig = appConfig, css = Some("print_preview"), articleLayout = false)(_)
+        case Result => layout(title(form, "result.title"), appConfig = appConfig)(_)
+        case ResultPrintPreview => layout(title(form, "site.letter.h1"), appConfig = appConfig, css = Some("print_preview"))(_)
         case ResultPDF => printTemplate(title(form, "result.title"), appConfig = appConfig)(_)
     }
 ){ template =>
@@ -42,18 +56,18 @@
         @pdfResultDetails.resultMode match {
             case Result => {
                 @pdfResultDetails.additionalPdfDetails.map { details =>
-                    @pdf.additional_details(details, pdfResultDetails.timestamp)
+                    @additional_details(details, pdfResultDetails.timestamp)
                 }
 
-                @components.teal_result(
+                @teal_result(
                     Html(messages(tailorMsg("result.officeHolder.ir35.heading"))),
                     "result.inside"
                 )
 
                 @formWithCsrf(ResultController.onSubmit, 'autoComplete -> "off") {
-                    @results.sections.why_result(whyResult)
-                    @results.sections.do_next(doNext)
-                    @results.sections.download()
+                    @why_result(whyResult)
+                    @do_next(doNext)
+                    @download()
                 }
             }
             case ResultPrintPreview => {
@@ -68,32 +82,32 @@
 }
 
 @whyResult = {
-    <p>@messages(tailorMsg("result.officeHolder.ir35.whyResult.p1"))</p>
+    <p class="govuk-body">@messages(tailorMsg("result.officeHolder.ir35.whyResult.p1"))</p>
 }
 
 @doNext = {
 
     @if(request.userType.contains(Hirer)) {
-        <p>@messages(tailorMsg("result.officeHolder.ir35.doNext.p1"))</p>
-        <p>
+        <p class="govuk-body">@messages(tailorMsg("result.officeHolder.ir35.doNext.p1"))</p>
+        <p class="govuk-body">
             @messages(tailorMsg("result.officeHolder.ir35.doNext.p2.preLink"))
-            @components.new_window_link(tailorMsg("result.officeHolder.ir35.doNext.p2.link"), appConfig.feePayerResponsibilitiesUrl, Some("feePayerResponsibilitiesLink")).
+            @newTabLink(tailorMsg("result.officeHolder.ir35.doNext.p2.link"), appConfig.feePayerResponsibilitiesUrl, Some("feePayerResponsibilitiesLink")).
         </p>
     } else {
         @if(isMakingDetermination) {
-            <p>@messages(tailorMsg("result.officeHolder.ir35.make.doNext.p1"))</p>
+            <p class="govuk-body">@messages(tailorMsg("result.officeHolder.ir35.make.doNext.p1"))</p>
         } else {
-            <p>@messages(tailorMsg("result.officeHolder.ir35.check.doNext.p1"))</p>
-            <p>@messages(tailorMsg("result.officeHolder.ir35.check.doNext.p2"))</p>
+            <p class="govuk-body">@messages(tailorMsg("result.officeHolder.ir35.check.doNext.p1"))</p>
+            <p class="govuk-body">@messages(tailorMsg("result.officeHolder.ir35.check.doNext.p2"))</p>
 
-            @contact_details()
+            @contact_details_new()
 
-            <p>
+            <p class="govuk-body">
                 @messages(tailorMsg("result.officeHolder.ir35.check.doNext.p3.preLink"))
-                @components.new_window_link(tailorMsg("result.officeHolder.ir35.check.doNext.p3.link"), appConfig.employmentStatusManualChapter5Url, Some("employmentStatusManualLink")).
+                @newTabLink(tailorMsg("result.officeHolder.ir35.check.doNext.p3.link"), appConfig.employmentStatusManualChapter5Url, Some("employmentStatusManualLink")).
             </p>
         }
     }
 
-    @results.sections.keep_copy(isMake = isMakingDetermination)
+    @keepCopy(isMake = isMakingDetermination)
 }

--- a/app/views/results/sections/letter/print_and_save_result_new.scala.html
+++ b/app/views/results/sections/letter/print_and_save_result_new.scala.html
@@ -18,7 +18,7 @@
 
 @()(implicit messages: Messages)
 
-<div class="" id="print-and-save-result">
+<div class="full-width" id="print-and-save-result">
   <h1 class="govuk-heading-xl">@messages("site.letter.h1")</h1>
 
    <div class="govuk-grid-row">

--- a/app/views/results/sections/letter/print_and_save_result_new.scala.html
+++ b/app/views/results/sections/letter/print_and_save_result_new.scala.html
@@ -18,11 +18,11 @@
 
 @()(implicit messages: Messages)
 
-<div class="full-width" id="print-and-save-result">
+<div class="" id="print-and-save-result">
   <h1 class="govuk-heading-xl">@messages("site.letter.h1")</h1>
 
-   <div class="grid-row">
-    <div id="printAndSave" class="column-full">
+   <div class="govuk-grid-row">
+    <div id="printAndSave" class="govuk-grid-column-full">
       <p class="form-group govuk-body" id="download">
         <a class="govuk-link" id="printLink" href="#" onclick="window.print();">
           @messages("site.letter.print")
@@ -35,7 +35,7 @@
 
       <p class="govuk-body">@messages("site.letter.copyOf.onceYouHave")</p>
 
-      <ul class="govuk-list">
+      <ul class="govuk-list govuk-list--bullet">
         <li>
           <a class="govuk-link" id="exitLink" href="@routes.ExitSurveyController.redirectToExitSurvey">@messages("site.letter.copyOf.exit")</a>
         </li>
@@ -46,4 +46,3 @@
     </div>
   </div>
 </div>
-

--- a/test/assets/messages/results/OfficeHolderMessages.scala
+++ b/test/assets/messages/results/OfficeHolderMessages.scala
@@ -32,7 +32,7 @@ object OfficeHolderMessages extends BaseResultMessages {
       val doNext_check_p1 = "If this result is different from the one you are checking, download a copy of this result and show it to your client. You should check your answers with them to make sure they are correct."
       val doNext_check_p2 = "If you need more guidance, you can contact HMRC’s Employment Status and Intermediaries helpline."
       val doNext_check_p3 = s"$telephone $telephoneNumber"
-      val doNext_check_p5 = "You could also read Chapter 5 of the Employment Status Manual (opens in a new window)."
+      val doNext_check_p5 = "You could also read Chapter 5 of the Employment Status Manual (opens in new tab)."
     }
   }
 
@@ -49,7 +49,7 @@ object OfficeHolderMessages extends BaseResultMessages {
       val heading = "Off-payroll working rules (IR35) apply"
       val whyResult_p1 = "In the ‘Worker’s Duties’ section, you answered that the worker will perform office holder duties. This means they are classed as employed for tax purposes for this work."
       val doNext_p1 = "If your organisation is responsible for paying the worker, you need to operate PAYE on their earnings. If someone else is responsible, you should download a copy of this result and show it to them."
-      val doNext_p2 = "You could also read more about the responsibilities of the fee-payer (opens in a new window)."
+      val doNext_p2 = "You could also read more about the responsibilities of the fee-payer (opens in new tab)."
     }
   }
 

--- a/test/views/results/OfficeHolderIR35ViewSpec.scala
+++ b/test/views/results/OfficeHolderIR35ViewSpec.scala
@@ -25,7 +25,7 @@ import play.twirl.api.Html
 import viewmodels.{Result, ResultMode, ResultPDF, ResultPrintPreview}
 import views.html.results.inside.officeHolder.OfficeHolderIR35View
 
-class OfficeHolderIR35ViewSpec extends ResultViewFixture {
+class OfficeHolderIR35ViewSpec extends ResultViewFixtureNew {
 
   val view = injector.instanceOf[OfficeHolderIR35View]
 


### PR DESCRIPTION
Migration of view
Factor out use of main template
Switch to use new templates

Note - there is an issue with the rendering of any additional details added through Add Details view which is not styles correctly currently (relates to sorting issue in letter section)

Consequently this should not be merged until this is resolved)

There is a supporting PR for ATs : https://github.com/hmrc/off-payroll-acceptance-tests/pull/216