### PR TITLE
DL-7533 migration of OfficeHolderPAYEView page

### DIFF
--- a/app/views/results/inside/officeHolder/OfficeHolderPAYEView.scala.html
+++ b/app/views/results/inside/officeHolder/OfficeHolderPAYEView.scala.html
@@ -17,7 +17,6 @@
 @import config.FrontendAppConfig
 @import uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 @import views.ViewUtils._
-@import results.sections.pdf
 @import models.sections.setup.WhoAreYou.Hirer
 @import models.requests.DataRequest
 @import results.sections.letter._
@@ -47,7 +46,7 @@
 
     pdfResultDetails.resultMode match {
         case Result => layout(title(form, "result.title"), appConfig = appConfig)(_)
-        case ResultPrintPreview => layout(title(form, "site.letter.h1"), appConfig = appConfig, css = Some("print_preview"))(_)
+        case ResultPrintPreview => layout(title(form, "site.letter.h1"), appConfig = appConfig, css = Seq(StyleSheet("print_preview"), StyleSheet("govuk_template_print", "print")))(_)
         case ResultPDF => printTemplate(title(form, "result.title"), appConfig = appConfig)(_)
     }
 ){ template =>

--- a/app/views/results/inside/officeHolder/OfficeHolderPAYEView.scala.html
+++ b/app/views/results/inside/officeHolder/OfficeHolderPAYEView.scala.html
@@ -22,17 +22,32 @@
 @import models.requests.DataRequest
 @import results.sections.letter._
 @import viewmodels.{LetterAnswerSections, Result, ResultMode, ResultPDF, ResultPrintPreview}
+@import results.sections._
 @import controllers.routes._
+@import views.html.components._
+@import views.html.templates._
+@import results.sections.pdf._
 
-@this(mainTemplate: templates.MainTemplate, printTemplate: templates.PrintTemplate, formWithCsrf: FormWithCSRF, letterLayout: letter_layout)
+@this(layout: layout,
+        printTemplate: PrintTemplateNew,
+        additionalDetails: additional_detailNew,
+        teal_result: teal_resultNew,
+        do_next: do_nextNew,
+        why_result: why_resultNew,
+        download: downloadNew,
+        newTabLink: new_tab_linkNew,
+        keepCopy: keep_copyNew,
+        letterLayout: letter_layout,
+        print_and_save_result: print_and_save_result_new,
+        formWithCsrf: FormWithCSRF)
 
 @(form: Form[_])(implicit request: DataRequest[_], messages: Messages, appConfig: FrontendAppConfig, pdfResultDetails: PDFResultDetails)
 
 @defining(
 
     pdfResultDetails.resultMode match {
-        case Result => mainTemplate(title(form, "result.title"), appConfig = appConfig)(_)
-        case ResultPrintPreview => mainTemplate(title(form, "site.letter.h1"), appConfig = appConfig, css = Some("print_preview"), articleLayout = false)(_)
+        case Result => layout(title(form, "result.title"), appConfig = appConfig)(_)
+        case ResultPrintPreview => layout(title(form, "site.letter.h1"), appConfig = appConfig, css = Some("print_preview"))(_)
         case ResultPDF => printTemplate(title(form, "result.title"), appConfig = appConfig)(_)
     }
 ){ template =>
@@ -43,18 +58,18 @@
 
             case Result => {
                 @pdfResultDetails.additionalPdfDetails.map { details =>
-                    @pdf.additional_details(details, pdfResultDetails.timestamp)
+                    @additional_details(details, pdfResultDetails.timestamp)
                 }
 
-                @components.teal_result(
+                @teal_result(
                     Html(messages(tailorMsg("result.officeHolder.paye.heading"))),
                     "result.inside"
                 )
 
                 @formWithCsrf(ResultController.onSubmit, 'autoComplete -> "off") {
-                    @results.sections.why_result(whyResult)
-                    @results.sections.do_next(doNext)
-                    @results.sections.download()
+                    @why_result(whyResult)
+                    @do_next(doNext)
+                    @download()
                 }
             }
             case ResultPrintPreview => {
@@ -69,19 +84,19 @@
 }
 
 @whyResult = {
-    <p>@messages(tailorMsg("result.officeHolder.paye.whyResult.p1"))</p>
+    <p class="govuk-body">@messages(tailorMsg("result.officeHolder.paye.whyResult.p1"))</p>
 }
 
 @doNext = {
     @if(request.userType.contains(Hirer)) {
-        <p>@messages(tailorMsg("result.officeHolder.paye.doNext.p1"))</p>
-        <p>
+        <p class="govuk-body">@messages(tailorMsg("result.officeHolder.paye.doNext.p1"))</p>
+        <p class="govuk-body">
             @messages(tailorMsg("result.officeHolder.paye.doNext.p2.preLink"))
-            @components.new_window_link(tailorMsg("result.officeHolder.paye.doNext.p2.link"), appConfig.payeForEmployersUrl, Some("payeForEmployersLink")).
+            @newTabLink(tailorMsg("result.officeHolder.paye.doNext.p2.link"), appConfig.payeForEmployersUrl, Some("payeForEmployersLink")).
         </p>
     } else {
-        <p>@messages(tailorMsg("result.officeHolder.paye.doNext.p1"))</p>
+        <p class="govuk-body">@messages(tailorMsg("result.officeHolder.paye.doNext.p1"))</p>
     }
 
-    @results.sections.keep_copy()
+    @keepCopy()
 }

--- a/app/views/results/sections/letter/print_and_save_result_new.scala.html
+++ b/app/views/results/sections/letter/print_and_save_result_new.scala.html
@@ -23,7 +23,7 @@
 
    <div class="govuk-grid-row">
     <div id="printAndSave" class="govuk-grid-column-full">
-      <p class="form-group govuk-body" id="download">
+      <p class="govuk-form-group govuk-body" id="download">
         <a class="govuk-link" id="printLink" href="#" onclick="window.print();">
           @messages("site.letter.print")
         </a>

--- a/app/views/results/sections/letter/print_and_save_result_new.scala.html
+++ b/app/views/results/sections/letter/print_and_save_result_new.scala.html
@@ -23,7 +23,7 @@
 
    <div class="govuk-grid-row">
     <div id="printAndSave" class="govuk-grid-column-full">
-      <p class="govuk-form-group govuk-body" id="download">
+      <p class="form-group govuk-body" id="download">
         <a class="govuk-link" id="printLink" href="#" onclick="window.print();">
           @messages("site.letter.print")
         </a>

--- a/test/assets/messages/results/OfficeHolderMessages.scala
+++ b/test/assets/messages/results/OfficeHolderMessages.scala
@@ -41,7 +41,7 @@ object OfficeHolderMessages extends BaseResultMessages {
       val heading = "Employed for tax purposes for this work"
       val whyResult_p1 = "In the ‘Worker’s Duties’ section, you answered that the worker will perform office holder duties. This means they are employed for tax purposes for this work."
       val doNext_p1 = "You need to operate PAYE on the worker’s earnings."
-      val doNext_p2 = "If this worker is your first employee, you could read this guidance about PAYE and payroll for employers (opens in a new window)."
+      val doNext_p2 = "If this worker is your first employee, you could read this guidance about PAYE and payroll for employers (opens in new tab)."
 
     }
 

--- a/test/views/results/OfficeHolderPAYEViewSpec.scala
+++ b/test/views/results/OfficeHolderPAYEViewSpec.scala
@@ -25,9 +25,9 @@ import play.twirl.api.Html
 import viewmodels.{Result, ResultMode, ResultPDF, ResultPrintPreview}
 import views.html.results.inside.officeHolder.OfficeHolderPAYEView
 
-class OfficeHolderPAYEViewSpec extends ResultViewFixture {
+class OfficeHolderPAYEViewSpec extends ResultViewFixtureNew {
 
-  val view = injector.instanceOf[OfficeHolderPAYEView]
+  val view: OfficeHolderPAYEView = injector.instanceOf[OfficeHolderPAYEView]
 
   val form = new DeclarationFormProvider()()
 


### PR DESCRIPTION
Migration of view
Factor out use of main template
Switch to use new templates

Note - there is an issue with the rendering of any additional details added through Add Details view which is not styles correctly currently (relates to sorting issue in letter section)

Consequently this should not be merged until this is resolved)

There is a supporting PR for ATs : 
https://github.com/hmrc/off-payroll-acceptance-tests/pull/217